### PR TITLE
Fixes fatal error on my install

### DIFF
--- a/classes/shortcode.php
+++ b/classes/shortcode.php
@@ -23,7 +23,7 @@ class Open_Table_Widget_Shortcode extends Open_Table_Widget {
 	function handle_shortcode( $atts ) {
 		$open_table_widget = new Open_Table_Widget();
 		//Only Load scripts when widget or shortcode is active
-		$open_table_widget->add_otw_widget_scripts();
+		$open_table_widget->frontend_widget_scripts();
 
 		//Defaults shortcode vals
 		$defaults = array(


### PR DESCRIPTION
I don't know how this has not been found, if it's the case. But every shortcode I put anywhere was breaking my install with a `Fatal error: Call to undefined method Open_Table_Widget::add_otw_widget_scripts() in /srv/www/wimpress/htdocs/wp-content/plugins/Open-Table-Widget-Pro/classes/shortcode.php on line 26`

So I investigated, and sure enough, there's no function with that name anywhere. So I changed it to `frontend_widget_scripts` and it unbreaks things.

Is nobody using this as a shortcode? Or did I miss something else?
